### PR TITLE
general_keycodes: fix broken assert

### DIFF
--- a/pyrepl/unix_eventqueue.py
+++ b/pyrepl/unix_eventqueue.py
@@ -73,8 +73,6 @@ def general_keycodes() -> Dict[bytes, str]:
     keycodes: Dict[bytes, str] = {}
     for key, tiname in _keynames.items():
         keycode = curses.tigetstr(tiname)
-        assert isinstance(keycode, bytes)
-        assert isinstance(key, str)
 
         trace("key {key} tiname {tiname} keycode {keycode!r}", **locals())
         if keycode:


### PR DESCRIPTION
The `isinstance(keycode, bytes)` assert would fail whenever `keycode == None`, which is not what we want