### PR TITLE
misc improvements

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -15,7 +15,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        python: ["3.8", "3.9", "3.10", "3.11"]
+        python: ["3.8", "3.9", "3.10", "3.11", "3.12"]
         tox_env: ["qa"]
 
     steps:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -22,7 +22,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        python: ["3.8", "3.9", "3.10", "3.11"]
+        python: ["3.8", "3.9", "3.10", "3.11", "3.12"]
 
     steps:
       - uses: actions/checkout@v4

--- a/pyrepl/historical_reader.py
+++ b/pyrepl/historical_reader.py
@@ -260,7 +260,7 @@ class HistoricalReader(R):
     def select_item(self, i: int):
         self.transient_history[self.historyi] = self.get_str()
         buf = self.transient_history.get(i)
-        self.buffer = list(buf if buf is not None else self.history[i])
+        self.buffer = list(self.history[i] if buf is None else buf)
         self.historyi = i
         self.pos = len(self.buffer)
         self.dirty = True

--- a/pyrepl/python_reader.py
+++ b/pyrepl/python_reader.py
@@ -74,9 +74,9 @@ class maybe_accept(commands.Command):
 
 
 from_line_prog = re.compile(
-    "^from\s+(?P<mod>[A-Za-z_.0-9]*)\s+import\s+(?P<name>[A-Za-z_.0-9]*)"
+    r"^from\s+(?P<mod>[A-Za-z_.0-9]*)\s+import\s+(?P<name>[A-Za-z_.0-9]*)"
 )
-import_line_prog = re.compile("^(?:import|from)\s+(?P<mod>[A-Za-z_.0-9]*)\s*$")
+import_line_prog = re.compile(r"^(?:import|from)\s+(?P<mod>[A-Za-z_.0-9]*)\s*$")
 
 
 def saver(reader=reader):

--- a/pyrepl/python_reader.py
+++ b/pyrepl/python_reader.py
@@ -145,10 +145,9 @@ class PythonicReader(CompletingReader, HistoricalReader):
                     mod = import_module(mod)
                     return [x for x in dir(mod) if x.startswith(name)]
             else:
-                return [x[len(mod) + 1 :] for x in l if x.startswith(mod + "." + name)]
+                return [x[len(mod) + 1 :] for x in l if x.startswith(f"{mod}.{name}")]
         try:
-            l = sorted(set(self.completer.complete(stem)))
-            return l
+            return sorted(set(self.completer.complete(stem)))
         except (NameError, AttributeError):
             return []
 

--- a/pyrepl/python_reader.py
+++ b/pyrepl/python_reader.py
@@ -24,20 +24,21 @@
 
 import atexit
 import code
-import imp
+import contextlib
 import os
 import re
 import sys
 import traceback
 import warnings
+from importlib import import_module
 
 from pyrepl import commands, completer, completing_reader, module_lister, reader
 from pyrepl.completing_reader import CompletingReader
 from pyrepl.historical_reader import HistoricalReader
 
 try:
-    imp.find_module("twisted")
-except ImportError:
+    import twisted
+except ModuleNotFoundError:
     default_interactmethod = "interact"
 else:
     default_interactmethod = "twistedinteract"
@@ -140,11 +141,9 @@ class PythonicReader(CompletingReader, HistoricalReader):
             try:
                 l = module_lister._packages[mod]
             except KeyError:
-                try:
-                    mod = __import__(mod, self.locals, self.locals, [""])
+                with contextlib.suppress(ImportError):
+                    mod = import_module(mod)
                     return [x for x in dir(mod) if x.startswith(name)]
-                except ImportError:
-                    pass
             else:
                 return [x[len(mod) + 1 :] for x in l if x.startswith(mod + "." + name)]
         try:

--- a/pyrepl/readline.py
+++ b/pyrepl/readline.py
@@ -395,7 +395,7 @@ def _make_stub(_name, _ret):
     def stub(*args, **kwds):
         import warnings
 
-        warnings.warn("readline.%s() not implemented" % _name, stacklevel=2)
+        warnings.warn(f"readline.{_name}() not implemented", stacklevel=2)
 
     stub.__name__ = _name
     globals()[_name] = stub

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,16 @@
+import pytest
+
+@pytest.fixture(scope="session", autouse=True)
+def isolate(tmp_path_factory):
+    """ avoids writing history files and/or using user-specific settings """
+    path = tmp_path_factory.mktemp("mock")
+    home_dir = path / "home"
+    home_dir.mkdir()
+
+
+    monkeypatch = pytest.MonkeyPatch()
+    monkeypatch.setenv("HOME", str(home_dir))
+
+    yield
+
+    monkeypatch.undo()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,6 @@
 import pytest
 
+
 @pytest.fixture(scope="session", autouse=True)
 def isolate(tmp_path_factory):
     """ avoids writing history files and/or using user-specific settings """

--- a/tests/infrastructure.py
+++ b/tests/infrastructure.py
@@ -16,9 +16,9 @@
 # RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF
 # CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
 # CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+from __future__ import annotations
 
-
-from typing import Tuple
+from typing import List, Optional, Tuple, Union
 
 from pyrepl.console import Console, Event
 from pyrepl.reader import Reader
@@ -32,38 +32,52 @@ class EqualsAnything:
 EA = EqualsAnything()
 
 
+Command = Union[
+    Tuple[str, Optional[str]],
+    Union[Tuple[str], str],
+]
+ExpectedScreen = Optional[List[str]]
+TestSpec = List[Tuple[Command, ExpectedScreen]]
+
+
 class TestConsole(Console):
-    def __init__(self, events, verbose=False):
+    def __init__(
+        self,
+        events: list[tuple[Command, ExpectedScreen]],
+        verbose: bool = False,
+    ):
         super().__init__(width=80, height=24, encoding="utf-8")
         self.events = events
-        self.next_screen = None
+        self.next_screen: list[str] | None = None
         self.verbose = verbose
 
-    def refresh(self, screen, xy: Tuple[int, int]):
+    def refresh(self, screen, xy: tuple[int, int]):
         if self.next_screen is not None:
             assert (
                 screen == self.next_screen
             ), f"[ {screen} != {self.next_screen} after {self.last_event_name} ]"
 
-    def get_event(self, block=True):
-        ev, sc = self.events.pop(0)
-        self.next_screen = sc
-        if not isinstance(ev, tuple):
-            ev = (ev, None)
-        self.last_event_name = ev[0]
+    def get_event(self, block: bool = True) -> Event:
+        event: Command
+        screen: ExpectedScreen
+        event, screen = self.events.pop(0)
+        self.next_screen = screen
+        if not isinstance(event, tuple):
+            event = (event, None)
+        self.last_event_name = event[0]
         if self.verbose:
-            print("event", ev)
-        return Event(*ev)
+            print(f"{event=}")
+        return Event(*event)
 
-    def getpending(self):
+    def getpending(self) -> Event:
         """Nothing pending, but do not return None here."""
-        return Event("key", "", b"")
+        return Event("key", "", "")
 
 
 class TestReader(Reader):
     __test__ = False
 
-    def get_prompt(self, lineno, cursor_on_line):
+    def get_prompt(self, lineno: int, cursor_on_line) -> str:
         return ""
 
     def refresh(self):
@@ -71,8 +85,9 @@ class TestReader(Reader):
         self.dirty = True
 
 
-def read_spec(test_spec, reader_class=TestReader):
+def read_spec(test_spec: TestSpec, reader_class=TestReader):
     # remember to finish your test_spec with 'accept' or similar!
     con = TestConsole(test_spec, verbose=True)
+
     reader = reader_class(con)
     reader.readline()

--- a/tests/test_bugs.py
+++ b/tests/test_bugs.py
@@ -70,3 +70,61 @@ def test_signal_failure(monkeypatch):
     finally:
         os.close(mfd)
         os.close(sfd)
+
+
+def test_down_historicalreader():
+    class HistoricalReaderWithHistory(HistoricalTestReader):
+        def __init__(self, *args, **kwargs):
+            super().__init__(*args, **kwargs)
+            self.history = ['print("hello")']
+            self.historyi = 1
+
+    read_spec(
+        [
+            ("up", ['print("hello")']),
+            ("up", ['print("hello")', "! start of buffer "]),
+            ("down", [""]),
+            ("down", ["", "! end of buffer "]),
+            ("accept", [""]),
+        ],
+        reader_class=HistoricalReaderWithHistory,
+    )
+
+
+def test_down_pythonicreader():
+    from pyrepl.python_reader import PythonicReader
+
+    class PythonicTestReader(PythonicReader, TestReader):
+        def __init__(self, console):
+            super().__init__(console, locals=[])
+
+        pass
+
+    read_spec(
+        [
+            ("up", ["", "! start of buffer "]),
+            ("down", ["", "! end of buffer "]),
+            ("accept", [""]),
+        ],
+        reader_class=PythonicTestReader,
+    )
+
+
+def test_down_pythonicreader_history():
+    from pyrepl.python_reader import PythonicReader
+
+    class PythonicTestReader(PythonicReader, TestReader):
+        def __init__(self, console):
+            super().__init__(console, locals=[])
+            self.history = ['print("hello")']
+
+    read_spec(
+        [
+            ("up", ['print("hello")']),
+            ("up", ['print("hello")', "! start of buffer "]),
+            ("down", [""]),
+            ("down", ["", "! end of buffer "]),
+            ("accept", [""]),
+        ],
+        reader_class=PythonicTestReader,
+    )

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{38,39,310,311,py3}, flake8
+envlist = py{38,39,310,311,312,py3}, flake8
 
 [testenv]
 deps =


### PR DESCRIPTION
- add regression test for HistoricalReader/PythonicReader
- tests: add isolate fixture
- get rid of deprecated "imp" module
- python_reader: use raw strings to define regexes
- use f-string, avoid declaring useless variables
- tox: add 3.12
- tests: add annotations to TestConsole/read_spec
- fix ruff warnings
