### PR TITLE
fix hang on macos

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -10,6 +10,7 @@ on:
 jobs:
   tests:
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 10
 
     strategy:
       fail-fast: false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,8 @@ on:
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
+
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest]
+        os: [ubuntu-latest, macos-latest]
         python: ["3.8", "3.9", "3.10", "3.11", "3.12"]
 
     steps:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,6 +17,7 @@ env:
 jobs:
   tests:
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 10
 
     strategy:
       fail-fast: false

--- a/tests/test_bugs.py
+++ b/tests/test_bugs.py
@@ -17,6 +17,8 @@
 # CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
 # CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
+import sys
+
 import pytest
 
 from pyrepl.historical_reader import HistoricalReader
@@ -45,6 +47,10 @@ def test_cmd_instantiation_crash():
     read_spec(spec, HistoricalTestReader)
 
 
+@pytest.mark.skipif(
+    sys.platform == "darwin" and sys.version_info < (3, 10, 9),
+    reason="prepare() hangs due to termios.tcdrain hanging on MacOS https://github.com/python/cpython/issues/97001",
+)
 def test_signal_failure(monkeypatch):
     import os
     import pty

--- a/tests/test_curses.py
+++ b/tests/test_curses.py
@@ -1,3 +1,5 @@
+import sys
+
 import pytest
 
 import pyrepl
@@ -7,9 +9,10 @@ from pyrepl.curses import setupterm
 def test_setupterm(monkeypatch):
     assert setupterm(None, 0) is None
 
+    exit_code = -1 if sys.platform == "darwin" else 0
     with pytest.raises(
         pyrepl._minimal_curses.error,
-        match=r"setupterm\(b?'term_does_not_exist', 0\) failed \(err=0\)",
+        match=rf"setupterm\(b?'term_does_not_exist', 0\) failed \(err={exit_code}\)",
     ):
         setupterm("term_does_not_exist", 0)
 

--- a/tests/test_readline.py
+++ b/tests/test_readline.py
@@ -1,5 +1,6 @@
 import os
 import pty
+import sys
 
 import pytest
 
@@ -12,6 +13,10 @@ def readline_wrapper():
     return _ReadlineWrapper(slave, slave)
 
 
+@pytest.mark.skipif(
+    sys.platform == "darwin" and sys.version_info < (3, 10, 9),
+    reason="readline() hangs due to termios.tcdrain hanging on MacOS https://github.com/python/cpython/issues/97001",
+)
 def test_readline():
     master, slave = pty.openpty()
     readline_wrapper = _ReadlineWrapper(slave, slave)
@@ -22,6 +27,10 @@ def test_readline():
     assert isinstance(result, bytes)
 
 
+@pytest.mark.skipif(
+    sys.platform == "darwin" and sys.version_info < (3, 10, 9),
+    reason="readline() hangs due to termios.tcdrain hanging on MacOS https://github.com/python/cpython/issues/97001",
+)
 def test_input():
     master, slave = pty.openpty()
     readline_wrapper = _ReadlineWrapper(slave, slave)
@@ -32,6 +41,10 @@ def test_input():
     assert isinstance(result, str)
 
 
+@pytest.mark.skipif(
+    sys.platform == "darwin" and sys.version_info < (3, 10, 9),
+    reason="readline() hangs due to termios.tcdrain hanging on MacOS https://github.com/python/cpython/issues/97001",
+)
 @pytest.mark.parametrize(
     "get_bytes,expected",
     [

--- a/tox.ini
+++ b/tox.ini
@@ -4,6 +4,7 @@ envlist = py{38,39,310,311,312,py3}, flake8
 [testenv]
 deps =
     pytest
+    pytest-timeout
     pexpect
     coverage: coverage
 commands =
@@ -15,7 +16,7 @@ passenv =
     PYTEST_ADDOPTS
     TERM
 setenv =
-    coverage: _PYREPL_TOX_RUN_CMD=coverage run -m pytest
+    coverage: _PYREPL_TOX_RUN_CMD=coverage run -m pytest --timeout=10
 
 [testenv:qa]
 deps =


### PR DESCRIPTION
- gha: enable tests on MacOS
- skip hanging tests on MacOS (python < 3.10.9)
- add timeout to all workflows (pytest-timeout)
- fix broken test_setupterm on MacOS