### PR TITLE
PyPi releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
 
 jobs:
-  deploy:
+  release:
     runs-on: ubuntu-latest
     timeout-minutes: 10
 
@@ -15,16 +15,22 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.9"
+          python-version: "3.13"
       - name: Install requirements
         run: |
-          pip install -U pip twine build
+          pip install -U twine nox[uv]==2025.2.9
       - name: Build
-        run: python -m build
-      - run: check-manifest
-      - run: twine check dist/*
+        run: nox -s build
+      - name:
+        if: ! startsWith(github.ref , 'refs/tags/')
+        run: |
+          echo "::warning::Not a tag, not uploading to PyPi"
+          ls -l dist/*
       - name: Publish to PyPI
+        if: startsWith(github.ref, 'refs/tags/')
         env:
           TWINE_USERNAME: "__token__"
           TWINE_PASSWORD: ${{ secrets.PYPI_TOKEN }}
-        run: twine upload dist/*
+        run: |
+          echo ${{github.ref}}
+          twine upload dist/*

--- a/README.md
+++ b/README.md
@@ -39,11 +39,11 @@ and ^N to move through the history)
 
 If you like what you see, you can install it with the familiar
 
-$ pip install git+https://github.com/bretello/pyrepl
+```console
+$ pip install pyrepl
+```
 
 which will also install `pythoni` script.
-
-PyPi version coming soon
 
 ## Changelog
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ write_to = "pyrepl/_version.py"
 
 [tool.ruff]
 target-version = "py38"
-exclude = ["fancycompleter/_version.py",]
+exclude = ["pyrepl/_version.py",]
 
 [tool.ruff.lint]
 select = [


### PR DESCRIPTION
- pyproject: fix ruff excludes (makes CI green again)
- gha: release: use nox -s build, cleanup
- README: update installation instructions
